### PR TITLE
Specify exact package versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,11 +30,11 @@ repositories {
 }
 
 dependencies {
-    compile 'io.airbrake:javabrake:0.1.+'
-    compile 'ch.qos.logback:logback-classic:1.2.+'
+    compile 'io.airbrake:javabrake:0.1.6'
+    compile 'ch.qos.logback:logback-classic:1.2.3'
     compile 'org.slf4j:slf4j-api:1.7.25'
 
-    testImplementation 'junit:junit:4.+'
+    testImplementation 'junit:junit:4.12'
 }
 
 test {

--- a/pom.xml
+++ b/pom.xml
@@ -17,13 +17,13 @@
     <dependency>
       <groupId>io.airbrake</groupId>
       <artifactId>javabrake</artifactId>
-      <version>0.1.+</version>
+      <version>0.1.6</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.+</version>
+      <version>1.2.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.+</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
The release process was resulting in errors with these `+` characters used to specify versions in the pom.xml. Our main library, [Javabrake](https://github.com/airbrake/javabrake/blob/master/build.gradle#L33-L39), does not use this version specification. We should specify the exact package versions we depend on to avoid this issue.

Fixes these errors when trying to release archive on Nexus staging:
```
Invalid POM: /io/airbrake/logback/0.1.1/logback-0.1.1.pom: 

Invalid version for Dependency {groupId=io.airbrake, artifactId=javabrake, version=0.1.+, type=jar} - 
uses invalid dynamic version syntax. Replace with a fixed version or standard mathematical notation e.g., 
[1.5,) for version 1.5 and higher. 

Invalid version for Dependency {groupId=ch.qos.logback, artifactId=logback-classic, version=1.2.+, type=jar} - 
uses invalid dynamic version syntax. Replace with a fixed version or standard mathematical notation e.g., 
[1.5,) for version 1.5 and higher. 

Invalid version for Dependency {groupId=junit, artifactId=junit, version=4.+, type=jar} - 
uses invalid dynamic version syntax. Replace with a fixed version or standard mathematical notation e.g., 
[1.5,) for version 1.5 and higher.
```